### PR TITLE
Fix duplicate ZOOKEEPER variable.

### DIFF
--- a/SmokeTest/bin/kafkaCleanUp.sh
+++ b/SmokeTest/bin/kafkaCleanUp.sh
@@ -9,7 +9,7 @@ export KAFKA_OPTS="-Dlog4j.configuration=file:./conf/tools-log4j.properties $KAF
 
 _KAFKA_TOPIC_OPTS="--command-config=./conf/kafka.conf-${KAFKA_SECURITY_TYPE}"
 
-#kafka-topics  --zookeeper "$KAFKA_ZOOKEEPER" --delete --topic "$TOPIC_NAME"
+#kafka-topics  --zookeeper "$KAFKA_ZOOKEEPER_QUORUM" --delete --topic "$TOPIC_NAME"
 kafka-topics "$_KAFKA_TOPIC_OPTS" --bootstrap-server "$KAFKA_HOST" --delete --topic "$TOPIC_NAME"
 rc=$?
 if [[ $rc != 0 ]]; then

--- a/SmokeTest/bin/kafkaTest.sh
+++ b/SmokeTest/bin/kafkaTest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./conf/SmokeConfig.config
 
-echo "KAFKA_ZOOKEEPER: $KAFKA_ZOOKEEPER"
+echo "KAFKA_ZOOKEEPER_QUORUM: $KAFKA_ZOOKEEPER_QUORUM"
 echo "KAFKA_HOST: $KAFKA_HOST"
 echo "TOPIC_NAME: $TOPIC_NAME"
 echo "KAFKA_INP_LOC: $KAFKA_INP_LOC"
@@ -12,7 +12,7 @@ export KAFKA_OPTS="-Dlog4j.configuration=file:./conf/tools-log4j.properties $KAF
 
 echo "Here creates the topic...!!!"
 _KAFKA_TOPIC_OPTS="--command-config=./conf/kafka.conf-${KAFKA_SECURITY_TYPE}"
-#kafka-topics  --zookeeper "$KAFKA_ZOOKEEPER" --create --topic "$TOPIC_NAME" --partitions 1 --replication-factor 1
+#kafka-topics  --zookeeper "$KAFKA_ZOOKEEPER_QUORUM" --create --topic "$TOPIC_NAME" --partitions 1 --replication-factor 1
 kafka-topics "$_KAFKA_TOPIC_OPTS" --bootstrap-server "$KAFKA_HOST" --create --topic "$TOPIC_NAME" --partitions 1 --replication-factor 1
 rc=$?
 if [[ $rc != 0 ]]; then

--- a/SmokeTest/bin/zkCleanUp.sh
+++ b/SmokeTest/bin/zkCleanUp.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 source ./conf/SmokeConfig.config
 
-echo "ZOOKEEPER: $ZOOKEEPER"
-echo "ZOOKEEPER_PATH: $ZOOKEEPER_PATH"
+echo "ZOOKEEPER_QUORUM: $ZOOKEEPER_QUORUM"
+echo "ZOOKEEPER_QUORUM_PATH: $ZOOKEEPER_QUORUM_PATH"
 
 #cat <<EOF >/tmp/zk-rm.$$
 #delete /zk_test
 #quit
 #EOF
-#cat /tmp/zk-rm.$$ | zookeeper-client -server $ZOOKEEPER
+#cat /tmp/zk-rm.$$ | zookeeper-client -server $ZOOKEEPER_QUORUM
 #rm -f /tmp/zk.$$ /tmp/zk-rm.$$
 
 export ZOO_LOG4J_PROP="ERROR,CONSOLE"
 
-printf "sync\ndelete %s\n" "$ZOOKEEPER_PATH" | zookeeper-client -server "$ZOOKEEPER"
+printf "sync\ndelete %s\n" "$ZOOKEEPER_QUORUM_PATH" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then

--- a/SmokeTest/bin/zkTest.sh
+++ b/SmokeTest/bin/zkTest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./conf/SmokeConfig.config
 
-#echo "ZOOKEEPER: $ZOOKEEPER"
+#echo "ZOOKEEPER_QUORUM: $ZOOKEEPER_QUORUM"
 #
 #cat <<EOF >/tmp/zk.$$
 #create /zk_test my_data
@@ -12,15 +12,15 @@ source ./conf/SmokeConfig.config
 #quit
 #EOF
 #
-#cat /tmp/zk.$$ | zookeeper-client -server $ZOOKEEPER
+#cat /tmp/zk.$$ | zookeeper-client -server $ZOOKEEPER_QUORUM
 #
 #exit
-echo "ZOOKEEPER: $ZOOKEEPER"
-echo "ZOOKEEPER_PATH: $ZOOKEEPER_PATH"
+echo "ZOOKEEPER_QUORUM: $ZOOKEEPER_QUORUM"
+echo "ZOOKEEPER_QUORUM_PATH: $ZOOKEEPER_QUORUM_PATH"
 
 export ZOO_LOG4J_PROP="ERROR,CONSOLE"
 
-printf "ls /\n" | zookeeper-client -server "$ZOOKEEPER"
+printf "ls /\n" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then
@@ -29,7 +29,7 @@ if [[ $rc != 0 ]]; then
   exit $rc
 fi
 
-printf "create %s my_data\n" "$ZOOKEEPER_PATH" | zookeeper-client -server "$ZOOKEEPER"
+printf "create %s my_data\n" "$ZOOKEEPER_QUORUM_PATH" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then
@@ -38,7 +38,7 @@ if [[ $rc != 0 ]]; then
   exit $rc
 fi
 
-printf "sync /\nget %s\n" "$ZOOKEEPER_PATH" | zookeeper-client -server "$ZOOKEEPER"
+printf "sync /\nget %s\n" "$ZOOKEEPER_QUORUM_PATH" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then
@@ -47,7 +47,7 @@ if [[ $rc != 0 ]]; then
   exit $rc
 fi
 
-printf "set %s junk\n" "$ZOOKEEPER_PATH" | zookeeper-client -server "$ZOOKEEPER"
+printf "set %s junk\n" "$ZOOKEEPER_QUORUM_PATH" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then
@@ -56,7 +56,7 @@ if [[ $rc != 0 ]]; then
   exit $rc
 fi
 
-printf "sync /\nget %s\n" "$ZOOKEEPER_PATH" | zookeeper-client -server "$ZOOKEEPER"
+printf "sync /\nget %s\n" "$ZOOKEEPER_QUORUM_PATH" | zookeeper-client -server "$ZOOKEEPER_QUORUM"
 rc=$?
 echo
 if [[ $rc != 0 ]]; then

--- a/SmokeTest/conf/SmokeConfig.config
+++ b/SmokeTest/conf/SmokeConfig.config
@@ -23,15 +23,15 @@ KERBEROS_SECURITY="false" # <-- verify (true/false)
 
 # ZooKeeper details
 #if [ -f /etc/hadoop/conf/hdfs-site.xml ]; then
-#  ZOOKEEPER=$(xmllint --xpath 'string(/configuration/property[name="ha.zookeeper.quorum"]/value)' /etc/hadoop/conf/hdfs-site.xml)
+#  ZOOKEEPER_QUORUM=$(xmllint --xpath 'string(/configuration/property[name="ha.zookeeper.quorum"]/value)' /etc/hadoop/conf/hdfs-site.xml)
 #  # yarn-site.xml yarn.resourcemanager.zk-address
 #  # yarn-site.xml hadoop.registry.zk.quorum
-#  if [ -z "$ZOOKEEPER" ]; then exit; fi
+#  if [ -z "$ZOOKEEPER_QUORUM" ]; then exit; fi
 #else
-#  ZOOKEEPER="localhost:2181" # <-- update
+#  ZOOKEEPER_QUORUM="localhost:2181" # <-- update
 #fi
-ZOOKEEPER="localhost:2181" # <-- update
-ZOOKEEPER_PATH="/zk_SmokeTest"
+ZOOKEEPER_QUORUM="localhost:2181" # <-- update
+ZOOKEEPER_QUORUM_PATH="/zk_SmokeTest"
 
 # HDFS details
 HDFS_PATH="/tmp/SmokeTest/"
@@ -101,9 +101,9 @@ SOLR_SSL_ENABLED="false" # <-- verify (true/false)
 # Read the files in conf/kafka.conf-* as they may need parts updated.
 KAFKA_SECURITY_TYPE="PLAINTEXT" # <-- verify (PLAINTEXT/SSL/SASL_PLAINTEXT/SASL_SSL)
 if [ -f /etc/kafka/conf/kafka-client.conf ]; then
-  KAFKA_ZOOKEEPER=$(awk -F= '$1~/^zookeeper.connect$/{print $2}' /etc/kafka/conf/kafka-client.conf) # <-- update
+  KAFKA_ZOOKEEPER_QUORUM=$(awk -F= '$1~/^zookeeper.connect$/{print $2}' /etc/kafka/conf/kafka-client.conf) # <-- update
 else
-  KAFKA_ZOOKEEPER="localhost:2181/kafka" # <-- update if not running on a Kafka Gateway
+  KAFKA_ZOOKEEPER_QUORUM="localhost:2181/kafka" # <-- update if not running on a Kafka Gateway
 fi
 KAFKA_HOST="localhost:9092" # <-- update
 TOPIC_NAME="kafka_smoke_test" # <-- update


### PR DESCRIPTION
In the config, we were using ZOOKEEPER as both a toggle to run the test and as the value of the ZK quorum location.  This PR separates those two values into separate variables.